### PR TITLE
CLI로 입력과 호출

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+import readline from "node:readline";
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+rl.question("당신의 이름은 무엇인가요? ", (answer) => {
+  console.log(`안녕하세요, ${answer}님! 👋`);
+  rl.close();
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "CLI",
+  "version": "1.0.0",
+  "main": "index.js",
+  "repository": "https://4BFC@github.com/Nodejs-API/CLI.git",
+  "author": "4BFC <4bee.code@gamil.com>",
+  "license": "MIT",
+  "bin": {
+    "hello-cli": "./index.js"
+  },
+  "type": "module"
+}


### PR DESCRIPTION
# CLI로 입력과 호출을 한다.
- yarn 환경으로 CLI환경을 구축한다.
- Commonjs가 아닌 ESModule 방식으로 코드를 구현한다.
- `chmod +x index.js`를 사용해서 index.js에 권한을 부여한다.
- #!/usr/bin/env node는 CLI로 실행될 수 있도록 해주는 shebang을 해준다.
- yarn link로 전역 CLI명령어를 등록한다.