### PR TITLE
CLI 배포하기

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const rl = readline.createInterface({
   output: process.stdout,
 });
 
-rl.question("당신의 이름은 무엇인가요? ", (answer) => {
-  console.log(`안녕하세요, ${answer}님! 👋`);
+rl.question("What is your name? ", (answer) => {
+  console.log(`Hello, ${answer}! 👋`);
   rl.close();
 });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "https://4BFC@github.com/Nodejs-API/CLI.git",
   "author": "4BFC <4bee.code@gamil.com>",
   "license": "MIT",
+  "description": "Hello, CLI",
   "bin": {
     "hello-cli": "./index.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@4bee/Hello-cli",
+  "name": "@4bee/hello-cli",
   "version": "1.0.0",
   "main": "index.js",
   "repository": "https://4BFC@github.com/Nodejs-API/CLI.git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "CLI",
+  "name": "@4bee/Hello-cli",
   "version": "1.0.0",
   "main": "index.js",
   "repository": "https://4BFC@github.com/Nodejs-API/CLI.git",


### PR DESCRIPTION
# CLI 배포하기
- CLI를 npm으로 배포한다.
- `npm login`으로 로그인한다.
- `npm publish --access public`으로 배포를 한다.
- npm에서 확인한다.

| 배포 결과물 |
|-----------|
| <img width="449" alt="image" src="https://github.com/user-attachments/assets/0e86aac4-259b-423e-abea-afb0cde21f45" width="300" /> |

- npm을 설치해본다.

| 배포 결과물 |
|-----------|
| <img width="269" alt="image" src="https://github.com/user-attachments/assets/9c7de6c5-d3b9-4c5f-9ba0-3bff72c292ff" width="300" /> |
| <img width="291" alt="image" src="https://github.com/user-attachments/assets/b2e98152-e594-48a9-a410-9b15ea591e36" width="300" /> |
| 설치 후 실행도 잘 된다. |

- npm 정책으로 72시간 내에 배포를 중지 및 제거한다. `npm unpublish YourPackageName --force`. 참고로 재배포시 등록한 버전으로는 배포가 되지 않는다.

| 배포 결과물 |
|-----------|
| <img width="399" alt="image" src="https://github.com/user-attachments/assets/ec328327-4add-4b5c-9b39-9c3d9ee7f4ff" width="300" /> |
| 잘 삭제 되었다. |


